### PR TITLE
Readme support 1.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,8 +72,11 @@ Next, install the ``FailedLoginMiddleware`` middleware::
     )
 
 
-Run ``python manage.py syncdb``.  This creates the appropriate tables in your database
-that are necessary for operation.
+For django(<1.7), 
+run ``python manage.py syncdb``.
+For django(>1.7), 
+run ``python manage.py makemigrations adminrestrict; python manage.py migrate``. 
+This creates the appropriate tables in your database that are necessary for operation.
 
 IMPORTANT: When the package is configured in your project, an empty table called `AllowedIP`
 will be created in your database. If this table is empty or has one record with

--- a/README.rst
+++ b/README.rst
@@ -72,11 +72,11 @@ Next, install the ``FailedLoginMiddleware`` middleware::
     )
 
 
-For django(<1.7), 
-run ``python manage.py syncdb``.
-For django(>1.7), 
-run ``python manage.py makemigrations adminrestrict; python manage.py migrate``. 
-This creates the appropriate tables in your database that are necessary for operation.
+Create the appropriate tables in your database that are necessary for operation.
+
+For django(<1.7), run ``python manage.py syncdb``.
+
+For django(>=1.7), run ``python manage.py makemigrations adminrestrict; python manage.py migrate``. 
 
 IMPORTANT: When the package is configured in your project, an empty table called `AllowedIP`
 will be created in your database. If this table is empty or has one record with


### PR DESCRIPTION
> https://docs.djangoproject.com/en/1.7/ref/django-admin/#syncdb

`syncdb` is deprecated since version 1.7. Thus, README.rst should be fixed as well.

Regards.