### PR TITLE
Prevent unintended caching of allow_always property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-django_axes.egg-info
+*.egg-info
 *.pyc
 build
 dist
@@ -10,3 +10,12 @@ examples/media/
 examples/static/
 examples/example/local_settings.py
 *~
+
+# virtualenvs
+env
+venv
+.env
+
+# ide folders
+.vscode
+.idea

--- a/adminrestrict/test_settings.py
+++ b/adminrestrict/test_settings.py
@@ -1,4 +1,3 @@
-import os
 import django
 
 if django.VERSION[:2] >= (1, 3):
@@ -11,7 +10,7 @@ if django.VERSION[:2] >= (1, 3):
 else:
     DATABASE_ENGINE = 'sqlite3'
 
-if django.VERSION[:2] >= (1, 8):    
+if django.VERSION[:2] >= (1, 8):
     TEMPLATES = [
         {
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
@@ -63,6 +62,3 @@ INSTALLED_APPS = [
 SECRET_KEY = 'too-secret-for-test'
 
 LOGIN_REDIRECT_URL = '/admin'
-
-
-

--- a/adminrestrict/test_urls.py
+++ b/adminrestrict/test_urls.py
@@ -17,13 +17,3 @@ else:
     urlpatterns = [
         path('admin/', admin.site.urls)
     ]
-
-
-    
-
-
-
-
-    
-
-

--- a/adminrestrict/tests.py
+++ b/adminrestrict/tests.py
@@ -27,12 +27,12 @@ class BasicTests(TestCase):
         self.user = User.objects.create_user(username="foo", password="bar")
 
     def test_disallow_get(self):
-        a = AllowedIP.objects.create(ip_address="10.10.0.1")        
+        a = AllowedIP.objects.create(ip_address="10.10.0.1")
         with self.settings(ADMINRESTRICT_BLOCK_GET=True):
             resp = self.client.get("/admin/")
             self.assertEqual(resp.status_code, 403)
         a.delete()
-            
+
     def test_allow_get_initial_page(self):
         a = AllowedIP.objects.create(ip_address="10.10.0.1")
         resp = self.client.get("/admin/")
@@ -48,14 +48,14 @@ class BasicTests(TestCase):
         else:
             self.assertEqual(resp.status_code, 302)
         a.delete()
-        
+
     def test_allow_all_if_empty(self):
         resp = self.client.post("/admin/", data={'username':"foo", 'password':"bar"})
         self.assertIn(resp.status_code, [200, 302])
 
     def test_allowed_ip(self):
         a = AllowedIP.objects.create(ip_address="4.4.4.4")
-        resp = self.client.post("/admin/", data={'username':"foo", 'password':"bar"}, 
+        resp = self.client.post("/admin/", data={'username':"foo", 'password':"bar"},
             follow=True, REMOTE_ADDR="4.4.4.4")
         self.assertEqual(resp.status_code, 200)
         a.delete()
@@ -79,7 +79,7 @@ class BasicTests(TestCase):
         self.assertEqual(resp.status_code, 403)
         self.assertEqual(resp.content, DENIED_MSG)
         a.delete()
-        
+
     def test_custom_denied_msg(self):
         DENIED_MSG = b"denied!"
         a = AllowedIP.objects.create(ip_address="16*")
@@ -88,7 +88,7 @@ class BasicTests(TestCase):
             self.assertEqual(resp.status_code, 403)
             self.assertEqual(resp.content, DENIED_MSG)
         a.delete()
-        
+
     def test_allow_all(self):
         a = AllowedIP.objects.create(ip_address="*")
         resp = self.client.post("/admin/", data={'username':"foo", 'password':"bar"}, follow=True)
@@ -107,19 +107,19 @@ class BasicTests(TestCase):
         a = AllowedIP.objects.create(ip_address="127.0.0.0/9100")
         resp = self.client.post("/admin/", data={'username':"foo", 'password':"bar"}, follow=True)
         self.assertEqual(resp.status_code, 403)
-        a.delete()   
+        a.delete()
 
     def test_allow_private_ip(self):
         a = AllowedIP.objects.create(ip_address="8.8.8.8")
         with self.settings(ADMINRESTRICT_ALLOW_PRIVATE_IP=True):
-            resp = self.client.post("/admin/", data={'username':"foo", 'password':"bar"}, 
+            resp = self.client.post("/admin/", data={'username':"foo", 'password':"bar"},
                 follow=True, REMOTE_ADDR="192.168.1.1")
             self.assertEqual(resp.status_code, 200)
         a.delete()
 
     def test_allow_domain_lookup(self):
         a = AllowedIP.objects.create(ip_address="ns4.zdns.google.")
-        resp = self.client.post("/admin/", data={'username':"foo", 'password':"bar"}, 
+        resp = self.client.post("/admin/", data={'username':"foo", 'password':"bar"},
                 follow=True, REMOTE_ADDR="216.239.38.114")
         self.assertEqual(resp.status_code, 200)
         a.delete()
@@ -142,22 +142,30 @@ class BasicTests(TestCase):
             resp = self.client.post("/admin/", data={'username':"foo", 'password':"bar"}, follow=True)
             self.assertEqual(resp.status_code, 403)
 
+    def test_add_first_restriction(self):
+        resp = self.client.post("/admin/", data={'username':"foo", 'password':"bar"}, follow=True)
+        self.assertEqual(resp.status_code, 200)
+
+        AllowedIP.objects.create(ip_address="8.8.8.8")
+        resp = self.client.post("/admin/", data={'username':"foo", 'password':"bar"}, follow=True)
+        self.assertEqual(resp.status_code, 403)
+
     def test_combined(self):
         AllowedIP.objects.create(ip_address="4.4.4.4")
         AllowedIP.objects.create(ip_address="a*")
         AllowedIP.objects.create(ip_address="168*")
         AllowedIP.objects.create(ip_address="ns4.zdns.google.")
 
-        resp = self.client.post("/admin/", data={'username':"foo", 'password':"bar"}, 
+        resp = self.client.post("/admin/", data={'username':"foo", 'password':"bar"},
             follow=True, REMOTE_ADDR="4.4.4.4")
         self.assertEqual(resp.status_code, 200)
-        resp = self.client.post("/admin/", data={'username':"foo", 'password':"bar"}, 
+        resp = self.client.post("/admin/", data={'username':"foo", 'password':"bar"},
             follow=True, REMOTE_ADDR="168.0.0.1")
         self.assertEqual(resp.status_code, 200)
-        resp = self.client.post("/admin/", data={'username':"foo", 'password':"bar"}, 
+        resp = self.client.post("/admin/", data={'username':"foo", 'password':"bar"},
             follow=True, REMOTE_ADDR="8.8.8.8")
         self.assertEqual(resp.status_code, 403)
-        resp = self.client.post("/admin/", data={'username':"foo", 'password':"bar"}, 
+        resp = self.client.post("/admin/", data={'username':"foo", 'password':"bar"},
             follow=True, REMOTE_ADDR="216.239.38.114")
         self.assertEqual(resp.status_code, 200)
 


### PR DESCRIPTION
In case no IP restrictions exist and caching is disabled in settings at the moment application is started, the `allow_always` property gets cached indefinitely with no ability to reset it. In such case adding new restrictions has no effect until application is restarted.

A test case is added to illustrate the situation - [link](https://github.com/robromano/django-adminrestrict/pull/15/files#diff-a2caa3e3002f302cfc7ce1c5eb00c5c7da20182230efdb9dadc1c5c04dec4c29R145-R152).
