### PR TITLE
Update - to _ per setuptools deprecation.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Per the discussion here: https://github.com/pypa/setuptools/issues/4910
`setuptools` has deprecated the use of `-` in the name of keys.